### PR TITLE
Fetch mobility data

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,6 +6,7 @@ const bodyParser = require('body-parser');
 
 const index = require('./routes/index');
 const schools = require('./routes/schools');
+const mobility = require('./routes/mobility');
 
 const app = express();
 
@@ -25,6 +26,7 @@ app.use(cookieParser());
 app.use(express.static(`${__dirname}/react-app/build`));
 // app.use('/', index);
 app.use('/schools', schools);
+app.use('/mobility', mobility);
 
 // catch 404 and forward to error handler
 app.use(function(req, res, next) {

--- a/react-app/package-lock.json
+++ b/react-app/package-lock.json
@@ -4555,13 +4555,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -4569,6 +4562,13 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -5716,14 +5716,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
-    "iso-3166-1-alpha-2": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/iso-3166-1-alpha-2/-/iso-3166-1-alpha-2-1.0.0.tgz",
-      "integrity": "sha1-vJ4LuU5YTfVGipMpl6KFUuJvl6w=",
-      "requires": {
-        "mout": "0.11.1"
-      }
-    },
     "isobject": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
@@ -6729,11 +6721,6 @@
       "version": "2.19.3",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.3.tgz",
       "integrity": "sha1-vbmdJw1tf9p4zA+6zoVeJ/59pp8="
-    },
-    "mout": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/mout/-/mout-0.11.1.tgz",
-      "integrity": "sha1-ujYR318OWx/7/QEWa48C0fX6K5k="
     },
     "ms": {
       "version": "2.0.0",
@@ -10047,14 +10034,6 @@
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-length": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
@@ -10071,6 +10050,14 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -13,7 +13,6 @@
     "halogenium": "^2.2.3",
     "husky": "^0.14.3",
     "i18n-iso-countries": "^3.3.0",
-    "iso-3166-1-alpha-2": "^1.0.0",
     "leaflet": "^1.2.0",
     "lodash": "^4.17.4",
     "prop-types": "^15.6.0",

--- a/react-app/src/actions/action-fetch-available-countries.js
+++ b/react-app/src/actions/action-fetch-available-countries.js
@@ -18,7 +18,7 @@ const fetchAvailableCountries = function() {
         dispatch({
           type: 'INITIAL_LOAD',
           payload: {
-            availableCountries: response.data.countries
+            availableCountries: response.data.properties
           }
         })
       })

--- a/react-app/src/actions/action-fetch-dates.js
+++ b/react-app/src/actions/action-fetch-dates.js
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import {fetchMobilityForDate} from '../helpers/helper-general'
+const config = require('../config.js')
 
 /**
  * countryStyle - Specifies the style for the geojson
@@ -8,12 +9,9 @@ import {fetchMobilityForDate} from '../helpers/helper-general'
  * @return {Array}
  */
 export function fetchDates(data) {
-  // if (!data) {
-  //   return []
-  // }
-  // return [[ new Date(2012, 3, 13), 37032 ]]
   return function(dispatch) {
-    axios.get('http://localhost:8000/api/v1/mobility/sources/acme/series/santiblanko/countries/col')
+    axios.get(window.location.origin + '/' +
+        config.initial_url_key[config.mode] + '/countries/' + data.id.toLowerCase())
       .catch(err => {
         alert('There was an error trying to do the initial fetch')
       })

--- a/react-app/src/actions/action-fetch-dates.js
+++ b/react-app/src/actions/action-fetch-dates.js
@@ -38,7 +38,7 @@ export function fetchDates(data) {
           payload: dates
         })
 
-        fetchMobilityForDate(dates[0])
+        fetchMobilityForDate(data.id.toLowerCase(), dates[0])
           .then(payload => {
             dispatch({
               type: 'DATE_SELECTED',

--- a/react-app/src/actions/action-select-country.js
+++ b/react-app/src/actions/action-select-country.js
@@ -1,8 +1,10 @@
 import arrToGeo from '../helpers/helper-2d-geojson'
-import axios from 'axios';
+import axios from 'axios'
+import {registerLocale, getName} from 'i18n-iso-countries'
 const config = require('../config.js')
 const mode = config.mode
-var iso3311a2 = require('iso-3166-1-alpha-2')
+
+registerLocale(require("i18n-iso-countries/langs/en.json"))
 /**
  * selectCountry - Specifies the style for the geojson
  *
@@ -29,7 +31,7 @@ export const selectCountry = (country, sliderVal) => {
         const headersList = response.data.result[0];
         const jsonData = response.data.result.slice(1)
         const points = arrToGeo(headersList, jsonData)
-        const countryname = iso3311a2.getCountry(country)
+        const countryname = getName(country, 'en')
         const numSchools = response.data.result.length - 1;
         // console.log(response.data.result[0]);
         let nschools = 0;

--- a/react-app/src/actions/action-select-date.js
+++ b/react-app/src/actions/action-select-date.js
@@ -5,9 +5,9 @@ import {fetchMobilityForDate} from '../helpers/helper-general'
  * @param  {String} date description
  * @return {object} dispatch
  */
-export const selectDate = function(date) {
+export const selectDate = function(country, date) {
   return function(dispatch) {
-    fetchMobilityForDate(date)
+    fetchMobilityForDate(country, date)
     .then(data => {
       dispatch({
         type: 'DATE_SELECTED',

--- a/react-app/src/components/MyMap.jsx
+++ b/react-app/src/components/MyMap.jsx
@@ -38,9 +38,6 @@ import {
   TileLayer
 } from 'react-leaflet'
 import {
-  alpha3ToAlpha2
-} from 'i18n-iso-countries';
-import {
   fetchDates
 } from '../actions/action-fetch-dates.js'
 import Docker from './Dock'
@@ -126,12 +123,9 @@ class MyMap extends Component {
   geoFilter(feature) {
     // If at country level
     if (feature.id) {
-      let alpha2 = alpha3ToAlpha2(feature.id);
-      if (this.props.availableCountries.indexOf(alpha2) > -1) {
-        return true
-      }
-      return false
+      return this.props.availableCountries.includes(feature.id.toLowerCase())
     }
+
     return true
   }
 

--- a/react-app/src/components/YearlyCalendar.js
+++ b/react-app/src/components/YearlyCalendar.js
@@ -17,10 +17,10 @@ import {
 class YearlyCalendar extends React.Component {
   onChange(Chart) {
     let index = Chart.chart.getSelection()[0].row
-    console.log('chart selection', Chart.chart.getSelection())
+    let country = this.props.activeCountry.polygons.properties.alpha3.toLowerCase()
 
     if (index !== undefined) {
-      this.props.selectDate(this.props.dates[index])
+      this.props.selectDate(country, this.props.dates[index])
     }
   }
 
@@ -41,7 +41,7 @@ class YearlyCalendar extends React.Component {
       id: 'Won/Loss'
     }]
 
-    if (this.props.dates[0].date.getYear() == 1) {
+    if (this.props.dates[0] === undefined) {
       return (<div></div>)
     }
 
@@ -68,14 +68,15 @@ function mapStateToProps(state) {
   return {
     dates: state.dates.dateArray,
     date: state.date,
-    visibility: state.dates.visibility
+    visibility: state.dates.visibility,
+    activeCountry: state.activeCountry
   }
 }
 
 function mapDispatchToProps(dispatch) {
   return {
-    selectDate: (data) => {
-      dispatch(selectDate(data))
+    selectDate: (country, data) => {
+      dispatch(selectDate(country, data))
     }
   }
 }

--- a/react-app/src/helpers/helper-countries-style.js
+++ b/react-app/src/helpers/helper-countries-style.js
@@ -1,6 +1,3 @@
-import {
-  alpha3ToAlpha2
-} from 'i18n-iso-countries';
 /**
  * countryStyle - Specifies the style for the geojson
  *
@@ -25,20 +22,19 @@ export function countryStyle(props) {
     // base_country indicates this is an admin 0
     // from valid countries array.
     if (geoJsonFeature.base_country) {
-      let alpha2 = alpha3ToAlpha2(geoJsonFeature.id);
       // Check if this country is one for which we have data.
-      if (props.availableCountries.indexOf(alpha2) > -1) {
+      if (props.availableCountries.includes(geoJsonFeature.id.toLowerCase())) {
         // If a country has been clicked on...
         // and this is that country...
         // Don't display. That will happen with the activeCountry layer
         let selectedCountry = activeCountry.selectedCountry ||
-          activeCountry.polygons.properties.alpha2
+          activeCountry.polygons.properties.alpha3
 
         // Points are schools, geojson is mobility now
         let geometry = (activeCountry.points.features.length > 0) ?
           activeCountry.points : activeCountry.polygons
         if (geometry.features.length > 0 &&
-          alpha2.match(selectedCountry)
+          geoJsonFeature.id.toLowerCase() === selectedCountry
         ) {
           return nullDisplay;
         }

--- a/react-app/src/helpers/helper-countries-style.js
+++ b/react-app/src/helpers/helper-countries-style.js
@@ -34,7 +34,7 @@ export function countryStyle(props) {
         let geometry = (activeCountry.points.features.length > 0) ?
           activeCountry.points : activeCountry.polygons
         if (geometry.features.length > 0 &&
-          geoJsonFeature.id.toLowerCase() === selectedCountry
+          geoJsonFeature.id.toLowerCase() === selectedCountry.toLowerCase()
         ) {
           return nullDisplay;
         }

--- a/react-app/src/helpers/helper-country-onEach.js
+++ b/react-app/src/helpers/helper-country-onEach.js
@@ -1,6 +1,3 @@
-import {
-  alpha3ToAlpha2
-} from 'i18n-iso-countries';
 const config = require('../config.js')
 /**
  * onEach
@@ -32,12 +29,11 @@ export function onEachCountryFeature(myMapObj, sliderVal) {
         // });
         // this.onEachFeature(feature, layer)
         // myMapObj.props.selectCountry(e.target.feature);
-        if (config.mode != 'schools') {
+        if (config.mode !== 'schools') {
           myMapObj.props.selectCountry(e.target.feature, sliderVal);
           myMapObj.props.fetchDates(e.target.feature);
         } else {
-          let alpha2 = alpha3ToAlpha2(e.target.feature.id);
-          myMapObj.props.selectCountry(alpha2, sliderVal);
+          myMapObj.props.selectCountry(e.target.feature.id.toLowerCase(), sliderVal);
           // if (alpha2 === 'BR' || alpha2 === 'CO') {
           //   myMapObj.setState({
           //     docker: true

--- a/react-app/src/helpers/helper-general.js
+++ b/react-app/src/helpers/helper-general.js
@@ -1,8 +1,11 @@
 import axios from 'axios';
+const config = require('../config')
 
-export function fetchMobilityForDate(date) {
+export function fetchMobilityForDate(country, date) {
   return new Promise((resolve, reject) => {
-    axios.get('http://localhost:8000/api/v1/mobility/sources/acme/series/santiblanko/countries/col/' + date.filename)
+    axios.get(window.location.origin + '/' +
+        config.initial_url_key[config.mode] + '/countries/' +
+        country + '/' + date.filename)
       .catch(err => {
         alert('There was an error trying to do the initial fetch')
       })

--- a/routes/mobility.js
+++ b/routes/mobility.js
@@ -9,38 +9,29 @@ const mobilityData = '/mobility/sources/acme/series/santiblanko/countries/'
 // Base url
 const baseUrl = `${magicboxUrl}${mobilityData}`
 
-router.get('/countries', (req, res, next) => {
-  axios.get(baseUrl)
+// Forward request to given url
+const forwardRequestToUrl = (res, url) => {
+  axios.get(url)
     .catch(err => {
       console.log('There was an error trying to get initial load BE');
     })
     .then(response => {
       res.json(response.data);
     })
-});
+}
+
+router.get('/countries', (req, res, next) => {
+  forwardRequestToUrl(res, baseUrl)
+})
 
 router.get('/countries/:country', (req, res, next) => {
   const url = `${baseUrl}${req.params.country}`;
-
-  axios.get(url)
-    .catch(err => {
-      console.log('There was an error trying to get initial load BE');
-    })
-    .then(response => {
-      res.json(response.data);
-    })
-});
+  forwardRequestToUrl(res, url)
+})
 
 router.get('/countries/:country/:filename', (req, res, next) => {
   const url = `${baseUrl}${req.params.country}/${req.params.filename}`;
-
-  axios.get(url)
-    .catch(err => {
-      console.log('There was an error trying to get initial load BE');
-    })
-    .then(response => {
-      res.json(response.data);
-    })
-});
+  forwardRequestToUrl(res, url)
+})
 
 module.exports = router;

--- a/routes/mobility.js
+++ b/routes/mobility.js
@@ -1,0 +1,43 @@
+// eslint-disable-next-line new-cap
+const router = require('express').Router();
+const axios = require('axios');
+const config = require('../react-app/src/config.js')
+const magicbox_url = process.env.magicbox_url || config.magicbox_url; // Magic box API url
+
+router.get('/countries', (req, res, next) => {
+  const url = `${magicbox_url}/mobility/sources/acme/series/santiblanko/countries/`;
+
+  axios.get(url)
+    .catch(err => {
+      console.log('There was an error trying to get initial load BE');
+    })
+    .then(response => {
+      res.json(response.data);
+    })
+});
+
+router.get('/countries/:country', (req, res, next) => {
+  const url = `${magicbox_url}/mobility/sources/acme/series/santiblanko/countries/${req.params.country}`;
+
+  axios.get(url)
+    .catch(err => {
+      console.log('There was an error trying to get initial load BE');
+    })
+    .then(response => {
+      res.json(response.data);
+    })
+});
+
+router.get('/countries/:country/:filename', (req, res, next) => {
+  const url = `${magicbox_url}/mobility/sources/acme/series/santiblanko/countries/${req.params.country}/${req.params.filename}`;
+
+  axios.get(url)
+    .catch(err => {
+      console.log('There was an error trying to get initial load BE');
+    })
+    .then(response => {
+      res.json(response.data);
+    })
+});
+
+module.exports = router;

--- a/routes/mobility.js
+++ b/routes/mobility.js
@@ -2,12 +2,15 @@
 const router = require('express').Router();
 const axios = require('axios');
 const config = require('../react-app/src/config.js')
-const magicbox_url = process.env.magicbox_url || config.magicbox_url; // Magic box API url
+const magicboxUrl = process.env.magicbox_url || config.magicbox_url; // Magic box API url
+
+// Mobility data
+const mobilityData = '/mobility/sources/acme/series/santiblanko/countries/'
+// Base url
+const baseUrl = `${magicboxUrl}${mobilityData}`
 
 router.get('/countries', (req, res, next) => {
-  const url = `${magicbox_url}/mobility/sources/acme/series/santiblanko/countries/`;
-
-  axios.get(url)
+  axios.get(baseUrl)
     .catch(err => {
       console.log('There was an error trying to get initial load BE');
     })
@@ -17,7 +20,7 @@ router.get('/countries', (req, res, next) => {
 });
 
 router.get('/countries/:country', (req, res, next) => {
-  const url = `${magicbox_url}/mobility/sources/acme/series/santiblanko/countries/${req.params.country}`;
+  const url = `${baseUrl}${req.params.country}`;
 
   axios.get(url)
     .catch(err => {
@@ -29,7 +32,7 @@ router.get('/countries/:country', (req, res, next) => {
 });
 
 router.get('/countries/:country/:filename', (req, res, next) => {
-  const url = `${magicbox_url}/mobility/sources/acme/series/santiblanko/countries/${req.params.country}/${req.params.filename}`;
+  const url = `${baseUrl}${req.params.country}/${req.params.filename}`;
 
   axios.get(url)
     .catch(err => {


### PR DESCRIPTION
# Summary

This PR creates routes to forward mobility requests to the API and handle the data returned from the API in the frontend to display available mobility data per country.

Depends on unicef/magicbox-open-api#39 to handle responses from schools/countries and mobility/countries uniformly.


Closes #30 
