### PR TITLE
Add cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2170,6 +2170,11 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
+    "memory-cache": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/memory-cache/-/memory-cache-0.2.0.tgz",
+      "integrity": "sha1-eJCwHVLADI68nVM+H46xfjA0hxo="
+    },
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "debug": "~2.6.9",
     "express": "~4.15.5",
     "jade": "~1.11.0",
+    "memory-cache": "^0.2.0",
     "morgan": "~1.9.0",
     "react-leaflet-webgl": "0.0.2",
     "serve-favicon": "~2.4.5",

--- a/routes/helper-router.js
+++ b/routes/helper-router.js
@@ -119,6 +119,21 @@ exports.forward_get = (req, res, next) => {
 }
 
 /**
+ * Forward request to given url
+ * @param  {object} res response object
+ * @param  {string} url
+ */
+exports.forward_request_to_url = (res, url) => {
+  axios.get(url)
+    .catch(err => {
+      console.log('There was an error trying to get initial load BE');
+    })
+    .then(response => {
+      res.json(response.data);
+    })
+}
+
+/**
  * This function provides a cache middleware to be used
  * with express
  *

--- a/routes/mobility.js
+++ b/routes/mobility.js
@@ -10,29 +10,18 @@ const mobilityData = '/mobility/sources/acme/series/santiblanko/countries/'
 // Base url
 const baseUrl = `${magicboxUrl}${mobilityData}`
 
-// Forward request to given url
-const forwardRequestToUrl = (res, url) => {
-  axios.get(url)
-    .catch(err => {
-      console.log('There was an error trying to get initial load BE');
-    })
-    .then(response => {
-      res.json(response.data);
-    })
-}
-
 router.get('/countries', helper.cache_response(300), (req, res, next) => {
-  forwardRequestToUrl(res, baseUrl)
+  helper.forward_request_to_url(res, baseUrl)
 })
 
 router.get('/countries/:country', helper.cache_response(300), (req, res, next) => {
   const url = `${baseUrl}${req.params.country}`;
-  forwardRequestToUrl(res, url)
+  helper.forward_request_to_url(res, url)
 })
 
 router.get('/countries/:country/:filename', helper.cache_response(300), (req, res, next) => {
   const url = `${baseUrl}${req.params.country}/${req.params.filename}`;
-  forwardRequestToUrl(res, url)
+  helper.forward_request_to_url(res, url)
 })
 
 module.exports = router;

--- a/routes/mobility.js
+++ b/routes/mobility.js
@@ -1,8 +1,9 @@
 // eslint-disable-next-line new-cap
 const router = require('express').Router();
+const helper = require('./helper-router')
 const axios = require('axios');
 const config = require('../react-app/src/config.js')
-const magicboxUrl = process.env.magicbox_url || config.magicbox_url; // Magic box API url
+const magicboxUrl = config.magicbox_url; // Magic box API url
 
 // Mobility data
 const mobilityData = '/mobility/sources/acme/series/santiblanko/countries/'
@@ -20,16 +21,16 @@ const forwardRequestToUrl = (res, url) => {
     })
 }
 
-router.get('/countries', (req, res, next) => {
+router.get('/countries', helper.cache_response(300), (req, res, next) => {
   forwardRequestToUrl(res, baseUrl)
 })
 
-router.get('/countries/:country', (req, res, next) => {
+router.get('/countries/:country', helper.cache_response(300), (req, res, next) => {
   const url = `${baseUrl}${req.params.country}`;
   forwardRequestToUrl(res, url)
 })
 
-router.get('/countries/:country/:filename', (req, res, next) => {
+router.get('/countries/:country/:filename', helper.cache_response(300), (req, res, next) => {
   const url = `${baseUrl}${req.params.country}/${req.params.filename}`;
   forwardRequestToUrl(res, url)
 })

--- a/routes/schools.js
+++ b/routes/schools.js
@@ -1,10 +1,10 @@
-const forward_get = require('./helper-router').forward_get
-const forward_get_with_token = require('./helper-router')
-  .forward_get_with_token
+const helper = require('./helper-router')
 const express = require('express');
 // eslint-disable-next-line new-cap
 const router = express.Router();
-router.get('/countries/:country', forward_get_with_token);
-router.get('/school/:school_id', forward_get_with_token);
-router.get('/countries', forward_get);
+
+router.get('/countries/:country', helper.cache_response(10), helper.forward_get_with_token);
+router.get('/school/:school_id', helper.cache_response(10), helper.forward_get_with_token);
+router.get('/countries', helper.cache_response(300), helper.forward_get);
+
 module.exports = router;


### PR DESCRIPTION
# Summary

This PR adds caching functionality easily tuned for specific routes needs.
The code used can be found [here](https://medium.com/the-node-js-collection/simple-server-side-cache-for-express-js-with-node-js-45ff296ca0f0).


Closes #42 