### PR TITLE
Add spinner mobility

### DIFF
--- a/react-app/src/actions/action-fetch-available-countries.js
+++ b/react-app/src/actions/action-fetch-available-countries.js
@@ -7,6 +7,7 @@ const mode = config.mode
  */
 const fetchAvailableCountries = function() {
   return function(dispatch) {
+    dispatch({type: 'REQUEST_DATA'})
     // Fetch all countries for which we have data for schools (mobility later)
     console.log(window.location.origin + '/' +
         config.initial_url_key[mode] + '/countries/', 'llll')
@@ -22,6 +23,8 @@ const fetchAvailableCountries = function() {
             availableCountries: response.data.properties
           }
         })
+
+        dispatch({type: 'RECEIVE_DATA'})
       })
   }
 }

--- a/react-app/src/actions/action-fetch-dates.js
+++ b/react-app/src/actions/action-fetch-dates.js
@@ -10,6 +10,8 @@ const config = require('../config.js')
  */
 export function fetchDates(data) {
   return function(dispatch) {
+    dispatch({type: 'REQUEST_DATA'})
+
     axios.get(window.location.origin + '/' +
       config.initial_url_key[config.mode] +
       '/countries/' + data.id.toLowerCase())
@@ -39,6 +41,7 @@ export function fetchDates(data) {
           type: 'FETCH_DATES',
           payload: dates
         })
+
         let most_recent_date = dates[dates.length-1]
         fetchMobilityForDate(data.id.toLowerCase(), most_recent_date)
           .then(payload => {
@@ -49,6 +52,8 @@ export function fetchDates(data) {
                 mobility: payload.data
               }
             })
+
+            dispatch({type: 'RECEIVE_DATA'})
           })
       })
   }

--- a/react-app/src/actions/action-select-country.js
+++ b/react-app/src/actions/action-select-country.js
@@ -22,6 +22,8 @@ export const selectCountry = (country, sliderVal) => {
     }
   }
   return function(dispatch) {
+    dispatch({type: 'REQUEST_DATA'})
+
     axios.get(window.location.origin + '/' +
       config.initial_url_key[mode] + '/countries/' + country)
       .catch(err => {
@@ -81,6 +83,8 @@ export const selectCountry = (country, sliderVal) => {
           speedresult = speedschools / nschools
           speedresult = speedresult.toFixed(2)
         }
+
+        dispatch({type: 'RECEIVE_DATA'})
 
         dispatch({
           type: 'COUNTRY_SELECTED',

--- a/react-app/src/actions/action-select-date.js
+++ b/react-app/src/actions/action-select-date.js
@@ -8,6 +8,8 @@ import {fetchMobilityForDate} from '../helpers/helper-general'
  */
 export const selectDate = function(country, date) {
   return function(dispatch) {
+    dispatch({type: 'REQUEST_DATA'})
+
     fetchMobilityForDate(country, date)
       .then(data => {
         dispatch({
@@ -17,6 +19,8 @@ export const selectDate = function(country, date) {
             mobility: data.data
           }
         })
+
+        dispatch({type: 'RECEIVE_DATA'})
       })
   }
 }

--- a/react-app/src/components/MyMap.jsx
+++ b/react-app/src/components/MyMap.jsx
@@ -780,7 +780,7 @@ class MyMap extends Component {
           ></GeoJSON>
         </Map>
         <Docker didUpdate={this.state.didUpdate}></Docker>
-        <LoadingSpinner display={this.state.loading}></LoadingSpinner>
+        <LoadingSpinner display={this.props.loading}></LoadingSpinner>
         <Popup style={style}/>
       </div>
     )
@@ -794,8 +794,8 @@ function mapStateToProps(state) {
     availableCountries: state.availableCountries.availableCountries,
     allCountries: state.allCountries,
     activeCountry: state.activeCountry,
-    sliderValues: state.sliderChanged
-
+    sliderValues: state.sliderChanged,
+    loading: state.loading
   }
 }
 

--- a/react-app/src/components/MyMap.jsx
+++ b/react-app/src/components/MyMap.jsx
@@ -696,19 +696,8 @@ class MyMap extends Component {
       // true is for whether to bind buffers
       this.state.onDrawLayer(this.state.info, true);
       if (this.state.docker) {
-        this.setState({
-          didUpdate: true,
-          loading: false
-        })
-      } else {
-        this.setState({
-          loading: false
-        })
+        this.setState({didUpdate: true})
       }
-      // Country has been clicked in mobility mode
-      // mobility data has arrived.
-    } else {
-      this.state.loading = false
     }
   }
 

--- a/react-app/src/helpers/helper-country-onEach.js
+++ b/react-app/src/helpers/helper-country-onEach.js
@@ -30,15 +30,11 @@ export function onEachCountryFeature(myMapObj, sliderVal) {
         if (config.mode != 'schools') {
           myMapObj.props.selectCountry(e.target.feature, sliderVal);
           myMapObj.props.fetchDates(e.target.feature);
-          myMapObj.setState({
-            loading: true
-          })
         } else {
           myMapObj.props.selectCountry(e.target.feature.id, sliderVal);
           myMapObj.setState({
             didUpdate: false,
-            docker: true,
-            loading: true
+            docker: true
           })
         }
       }

--- a/react-app/src/reducers/index.js
+++ b/react-app/src/reducers/index.js
@@ -7,6 +7,7 @@ import allCountriesReducer from './reducer-all-countries';
 import availableCountriesReducer from './reducer-available-countries';
 import activeCountryReducer from './reducer-active-country';
 import sliderChangedReducer from './reducer-slider-changed';
+import loadingDataReducer from './reducer-loading-data'
 
 
 const allReducers = combineReducers({
@@ -15,7 +16,8 @@ const allReducers = combineReducers({
   date: dateReducer,
   allCountries: allCountriesReducer,
   availableCountries: availableCountriesReducer,
-  sliderChanged: sliderChangedReducer
+  sliderChanged: sliderChangedReducer,
+  loading: loadingDataReducer
 })
 
 export default allReducers;

--- a/react-app/src/reducers/reducer-loading-data.js
+++ b/react-app/src/reducers/reducer-loading-data.js
@@ -1,0 +1,16 @@
+const initialState = false
+
+/**
+ * @param  {Object} state state
+ * @param  {Object} action action
+ * @return {Object} new state
+ */
+export default (state = initialState, action) => {
+  switch (action.type) {
+  case 'REQUEST_DATA':
+    return true
+  case 'RECEIVE_DATA':
+    return false
+  }
+  return state;
+}


### PR DESCRIPTION
# Summary

This PR adds the loading spinner for mobility map. It does so by adding the state "loading" to the store instead of dealing with this state outside the store as was being handled before.

This approach make it possible to dispatch actions to display and hide the load spinner (REQUEST_DATA, RECEIVE_DATA) and abstracts inner business logic to deal with when those actions are triggered.

Closes #37 