### PR TITLE
Add linear interpolation function to aggregate indexes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -118,9 +118,11 @@ class App extends Component {
           type: 'geojson',
           data: component.state.regions
         },
+        layout: {
+          visibility: 'none'
+        },
         paint: {
-          'fill-color': '#088',
-          'fill-opacity': 0.0
+          'fill-opacity': 0.5
         }
       });
 
@@ -178,15 +180,37 @@ class App extends Component {
   }
 
   changeRegionPaintPropertyHandler(e) {
+    // lowest and highest color value
+    const [ lowerColor, higherColor ] = [ '#fff', '#088' ]
+
+    // Get all checked inputs for regions
     let matches = document.querySelectorAll("input[name=region]:checked");
+
+    // Change layer visibility if there are matches
+    this.state.map.setLayoutProperty('regions', 'visibility', matches.length ? 'visible' : 'none')
+
+    if (!matches.length) {
+      // no region selected
+      return
+    }
+
+    // build the aggregation query
     let atts_to_aggregate = Array.prototype.slice.call(matches).reduce((a,t) => {
       a.push(['get', t.value])
       return a
     }, ['+'])
+
+    // Set new paint property to color the map
     this.state.map.setPaintProperty(
       'regions',
-      'fill-opacity',
-      ['/', atts_to_aggregate, atts_to_aggregate.length-1]
+      'fill-color',
+      // linear interpolation for colors going from lowerColor to higherColor accordingly to aggregation value
+      ['interpolate',
+        ['linear'],
+        ['/', atts_to_aggregate, atts_to_aggregate.length-1],
+        0, lowerColor,
+        1, higherColor
+      ]
     )
   }
 


### PR DESCRIPTION
# Summary

This PR adds a linear interpolation function that allows a value in the range [0, 1] to be mapped to a color [lowerColor, higherColor] respectively. Thus, allowing multiple colors (right now, only 2) to be used while aggregating indexes, also setting the general layer opacity to 0.5, allowing the user to read the region's name independently of the aggregation value.

Images are shown as example, not representing the current values set for colors.

![screenshot from 2018-04-04 15-34-46](https://user-images.githubusercontent.com/16000613/38327232-22c4838c-381e-11e8-878e-1d0aaa686e66.png)
![screenshot from 2018-04-04 15-35-29](https://user-images.githubusercontent.com/16000613/38327233-22e64030-381e-11e8-999d-944395143813.png)
![screenshot from 2018-04-04 15-36-35](https://user-images.githubusercontent.com/16000613/38327234-2301cdd2-381e-11e8-84ed-5d189cf2f5a6.png)
