### PR TITLE
Add mapbox token as an environment variable

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -18,7 +18,7 @@ import apiConfig from './helpers/api-config'
 // Main style
 import './App.css';
 
-mapboxgl.accessToken = 'pk.eyJ1IjoicmRlYmVhc2ktcmgiLCJhIjoiY2pkcWQ2YXVxMHJkczJxcWxtZHhoNGtmdSJ9.3XajiSFSZPwtB4_ncmmaHQ';
+mapboxgl.accessToken = apiConfig.mapboxToken
 
 class App extends Component {
   constructor(props: Props) {

--- a/src/helpers/api-config.js
+++ b/src/helpers/api-config.js
@@ -3,7 +3,8 @@
 
 const apiConfig = {
   schools: process.env.REACT_APP_SCHOOLS_URL,
-  shapes: process.env.REACT_APP_SHAPES_URL
+  shapes: process.env.REACT_APP_SHAPES_URL,
+  mapboxToken: process.env.REACT_APP_MAPBOX_TOKEN
 }
 
 export default apiConfig;


### PR DESCRIPTION
# Summary

This PR expects a new environment variable called REACT_APP_MAPBOX_TOKEN to exist and stores it as mapboxToken inside the helper file api-config in order to use this value as the token to access mapbox.

https://github.com/orgs/unicef/projects/4#card-8700251
