### PR TITLE
2.0 fix data load issue

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -78,7 +78,6 @@ class App extends Component {
       myJson.features = calculate_index(
         myJson.features, 'violence', 'violence_index'
       )
-      component.setState({regions: myJson});
 
       return myJson
     }).then((geojson) => {
@@ -131,7 +130,10 @@ class App extends Component {
         // Add a GeoJSON source containing place coordinates and information.
         source: {
           type: 'geojson',
-          data: component.state.regions
+          data: {
+            type: "FeatureCollection",
+            features: []
+          }
         },
         layout: {
           visibility: 'none'
@@ -147,7 +149,10 @@ class App extends Component {
         // Add a GeoJSON source containing place coordinates and information.
         source: {
           type: 'geojson',
-          data: component.state.schools
+          data: {
+            type: "FeatureCollection",
+            features: []
+          }
         },
         paint: {
           'circle-radius': {

--- a/src/App.js
+++ b/src/App.js
@@ -66,6 +66,11 @@ class App extends Component {
       })
     })
 
+    // Set data for regions when regions and map are available
+    Promise.all([shapesPromise, mapLoadPromise]).then(([geojson, map]) => {
+      map.getSource('regions').setData(geojson)
+    })
+
     // Set data for schools when regions and map are available
     Promise.all([schoolsPromise, mapLoadPromise]).then(([geojson, map]) => {
       map.getSource('schools').setData(geojson)

--- a/src/App.js
+++ b/src/App.js
@@ -43,15 +43,14 @@ class App extends Component {
   }
 
   componentDidMount() {
-    let component = this;
-
     const map = new mapboxgl.Map({
       container: this.mapContainer,
       style: 'mapbox://styles/mapbox/streets-v9',
-      center: [component.state.lng, component.state.lat],
-      zoom: component.state.zoom
+      center: [this.state.lng, this.state.lat],
+      zoom: this.state.zoom
     });
-    component.setState({map: map});
+
+    this.setState({map});
     
     // Promises
     let shapesPromise  = fetch(apiConfig.shapes).then((response) => response.json())
@@ -106,7 +105,7 @@ class App extends Component {
         return self.indexOf(el) === i
       })
 
-      component.setState({regionNames})
+      this.setState({regionNames})
     })
 
     // Handle school data
@@ -126,7 +125,7 @@ class App extends Component {
     map.on('move', () => {
       const { lng, lat } = map.getCenter();
 
-      component.setState({
+      this.setState({
         lng: lng.toFixed(4),
         lat: lat.toFixed(4),
         zoom: map.getZoom().toFixed(2)

--- a/src/App.js
+++ b/src/App.js
@@ -66,6 +66,11 @@ class App extends Component {
       })
     })
 
+    // Set data for schools when regions and map are available
+    Promise.all([schoolsPromise, mapLoadPromise]).then(([geojson, map]) => {
+      map.getSource('schools').setData(geojson)
+    })
+
     // Handle shapes data
     shapesPromise.then(function(myJson) {
       // Calculate indexes


### PR DESCRIPTION
# Summary

This PR fixes the race condition between the map load event and data retrieval for schools (and regions, altough not observed at first) by wrapping the event inside a promise and setting the corresponding data sources after both, map and data, become available.