### PR TITLE
Remove school names from Select auto-complete, else app is sluggish a…

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -126,7 +126,7 @@ class App extends Component {
       })
 
       this.setState({
-        schoolNames,
+        // schoolNames,
         connectivityTotals: countConnectivity(geojson.features)
       })
     })


### PR DESCRIPTION
When school names are added to schools.json, the app gets prohibitively sluggish. This is because the Select component is rendered constantly on map pan. This okay for 1200 admin names, but not 40k schools names.

Quick fix is to remove school names from Select until solution is found to only have  createFilterOptions({options})} when options change.