### PR TITLE
Multiple countries shapefiles (fixes #93)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,6 +10,8 @@ module.exports = {
     "react"
   ],
   'rules': {
+    'linebreak-style': 0,
+    'global-require': 0,
     "arrow-parens": 0,
     "react/jsx-uses-vars": [2],
     // need to keep as it's known issue with a dependency of airbnb standards

--- a/react-app/src/helpers/helper-country-onEach.js
+++ b/react-app/src/helpers/helper-country-onEach.js
@@ -5,9 +5,14 @@ const config = require('../config.js')
  *
  * @param {object} myMapObj
  * @param {number} sliderVal value
+ * @param {object} availableCountryPaths
  * @return {function} function
  */
-export function onEachCountryFeature(myMapObj, sliderVal, availableCountryPaths) {
+export function onEachCountryFeature(
+  myMapObj,
+  sliderVal,
+  availableCountryPaths
+) {
   return (feature, layer) => {
     layer.on({
       'mouseover': (e) => {

--- a/react-app/src/helpers/helper-country-point.js
+++ b/react-app/src/helpers/helper-country-point.js
@@ -1,7 +1,7 @@
-import axios from 'axios';
-import popUpString from './helper-popup-string';
-const config = require('../config.js')
-const mode = config.mode
+// import axios from 'axios';
+// import popUpString from './helper-popup-string';
+// const config = require('../config.js')
+// const mode = config.mode
 
 
 /**

--- a/react-app/src/helpers/helper-general.js
+++ b/react-app/src/helpers/helper-general.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-const config = require('../config')
+// const config = require('../config')
 
 /**
  * Fetch mobility for date

--- a/react-app/src/helpers/helper-point-click.js
+++ b/react-app/src/helpers/helper-point-click.js
@@ -4,9 +4,10 @@ import popUpString from './helper-popup-string';
 /**
  * pointClick - makes point to layer
  *
- * @param  {Number} school_id
+ * @param  {object} feature
  * @param  {Obj} map
  * @param  {String} fetch_url
+ *
  */
 export default function pointClick(feature, map, fetch_url) {
   let url = fetch_url + feature.properties.id;

--- a/routes/shapefiles.js
+++ b/routes/shapefiles.js
@@ -2,9 +2,16 @@ const express = require('express');
 // eslint-disable-next-line new-cap
 const router = express.Router();
 
-const mpio = require('../public/mpio.json');
-
 router.get('/:country', (req, res) => {
-  res.send(mpio)
+  _parsedUrl = req['_parsedUrl']
+  path = _parsedUrl['path']
+  console.log('path' + path)
+  if ( path === '/COD' ) {
+    const cod = require('../public/cod_2.json');
+    res.send(cod)
+  } else if ( path == '/COL' ) {
+    const mpio = require('../public/mpio.json');
+    res.send(mpio)
+  }
 })
 module.exports = router;


### PR DESCRIPTION
This PR enables the API to serve shapefile for multiple countries. It also modifies `.eslintrc.js` to make ESLint compatible with WinOS, and provides a few lint fixes in some other files. 